### PR TITLE
[eclipse/xtext-xtend#712] Remove Andoid archetype

### DIFF
--- a/artifacts.gradle
+++ b/artifacts.gradle
@@ -86,10 +86,6 @@ osspub {
 			excludeClassifier 'javadoc'
 		}
 		artifact {
-			name 'xtend-android-archetype'
-			excludeClassifier 'javadoc'
-		}
-		artifact {
 			name 'org.eclipse.xtend.maven.parent'
 			excludeExtension 'jar'
 		}


### PR DESCRIPTION
Archetype is discontinued with 2.17

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>