### PR TITLE
[eclipse/xtext#1424] Change default Jenkins to ci.eclipse.org

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'io.typefox.osspub'
 apply from: 'artifacts.gradle'
 
 if (!hasProperty('JENKINS_URL')) {
-  ext.JENKINS_URL = 'http://services.typefox.io/open-source/jenkins'
+  ext.JENKINS_URL = 'https://ci.eclipse.org/xtext'
 }
 
 def mavenSource = findProperty('mavenSource')


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>