### PR TITLE
increase retry count and use default delay algorithm

### DIFF
--- a/buildSrc/src/main/java/io/typefox/publishing/tasks/JarSignTask.xtend
+++ b/buildSrc/src/main/java/io/typefox/publishing/tasks/JarSignTask.xtend
@@ -136,7 +136,7 @@ class JarSignTask extends DefaultTask {
 					executable = 'curl'
 					args = #[
 						'--fail',
-						'--retry', '3', '--retry-delay', '10',
+						'--retry', '10',
 						'--silent', '--show-error',
 						'--write-out', STDOUT_FORMAT,
 						'--output', target.path,
@@ -152,7 +152,7 @@ class JarSignTask extends DefaultTask {
 						executable = 'curl'
 						args = #[
 							'--silent',
-							'--retry', '3', '--retry-delay', '10',
+							'--retry', '10',
 							'--form', '''file=@«source.path»''',
 							SIGNING_SERVICE
 						]


### PR DESCRIPTION
increase retry count and use default delay algorithm
https://bugs.eclipse.org/bugs/show_bug.cgi?id=573567
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>